### PR TITLE
Fixes compilation error for precommit "lint-staged"

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,10 +1,10 @@
-const path = require('path');
+import path from 'path';
 
 const buildEslintCommand = filenames =>
   `next lint --fix --file ${filenames
     .map(f => path.relative(process.cwd(), f))
     .join(' --file ')}`;
 
-module.exports = {
+export default {
   '*.{js,jsx,ts,tsx}': [buildEslintCommand],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@fractalwagmi/fractal-sdk": "^0.1.27",
+        "@fractalwagmi/fractal-sdk": "^0.2.1",
         "next": "latest",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@fractalwagmi/fractal-sdk": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk/-/fractal-sdk-0.1.27.tgz",
-      "integrity": "sha512-EuKu0QFtUhwyaUZ/oIRhkSZ9EQoXZ+AY1JCPF1fUHq9x+mk7747RmaAImxGDY2axoVWdo4bViHBzi+FA6xEl0g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk/-/fractal-sdk-0.2.2.tgz",
+      "integrity": "sha512-FFSEzFNbQeFYg8+4/REpILm1jxrA+DnQcLOj/sBZOcxRWGbyz5Z59KQvft3P1mTvKPE+82HnkQggL8qZd5DUYg==",
       "dependencies": {
         "@solana/wallet-adapter-react": "^0.15.4",
         "@solana/web3.js": "^1.37.1",
@@ -5360,9 +5360,9 @@
       }
     },
     "@fractalwagmi/fractal-sdk": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk/-/fractal-sdk-0.1.27.tgz",
-      "integrity": "sha512-EuKu0QFtUhwyaUZ/oIRhkSZ9EQoXZ+AY1JCPF1fUHq9x+mk7747RmaAImxGDY2axoVWdo4bViHBzi+FA6xEl0g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/fractal-sdk/-/fractal-sdk-0.2.2.tgz",
+      "integrity": "sha512-FFSEzFNbQeFYg8+4/REpILm1jxrA+DnQcLOj/sBZOcxRWGbyz5Z59KQvft3P1mTvKPE+82HnkQggL8qZd5DUYg==",
       "requires": {
         "@solana/wallet-adapter-react": "^0.15.4",
         "@solana/web3.js": "^1.37.1",


### PR DESCRIPTION
I was getting the error:

```
ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/Users/kan/Projects/sdk-demo/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

I just changed the commonJS style to ESM and it seems to work fine.